### PR TITLE
feat: 상품상세 페이지로 이동 기능 추가, Header 적용

### DIFF
--- a/src/app/product-register-history/_components/product-register-table.tsx
+++ b/src/app/product-register-history/_components/product-register-table.tsx
@@ -50,7 +50,10 @@ export function ProductRegisterTable({
               <TableRow key={item.id}>
                 <TableCell className="text-gray-700">{item.registeredAt}</TableCell>
                 <TableCell>
-                  <div className="flex items-center gap-3">
+                  <Link
+                    href={`/products/${item.id}`}
+                    className="flex items-center gap-3 group"
+                  >
                     <div className="relative h-12 w-12 shrink-0 overflow-hidden rounded-md bg-gray-100">
                       <Image
                         src={item.imageUrl}
@@ -60,8 +63,10 @@ export function ProductRegisterTable({
                         sizes="48px"
                       />
                     </div>
-                    <span className="text-gray-700 truncate">{item.name}</span>
-                  </div>
+                    <span className="text-gray-700 truncate group-hover:text-gray-900 group-hover:underline">
+                      {item.name}
+                    </span>
+                  </Link>
                 </TableCell>
                 <TableCell className="text-gray-600">{item.category}</TableCell>
                 <TableCell className="text-gray-700">

--- a/src/app/product-register-history/_lib/api.ts
+++ b/src/app/product-register-history/_lib/api.ts
@@ -2,7 +2,20 @@ import { mockProductRegistrations } from "./mock-data";
 import type {
   GetProductRegistrationsParams,
   GetProductRegistrationsResult,
+  ProductRegistration,
 } from "./types";
+
+export async function getProductRegistrationById(
+  productId: number
+): Promise<ProductRegistration | null> {
+  if (!Number.isFinite(productId)) {
+    return null;
+  }
+  await new Promise((resolve) => setTimeout(resolve, 80));
+  return (
+    mockProductRegistrations.find((item) => item.id === productId) ?? null
+  );
+}
 
 export async function getProductRegistrations(
   params: GetProductRegistrationsParams = {}

--- a/src/app/product-register-history/page.tsx
+++ b/src/app/product-register-history/page.tsx
@@ -2,10 +2,13 @@
 
 import { ProductRegisterHeader } from "./_components/product-register-header";
 import { ProductRegisterTable } from "./_components/product-register-table";
+import { Header } from "@/components/header";
 import Pagination from "@/components/ui/pagination";
+import { useMediaQuery } from "@/hooks/use-media-query";
 import { useProductRegistrations } from "./_hooks/use-product-registrations";
 
 export default function ProductRegisterHistoryPage() {
+  const isMobile = useMediaQuery("(max-width: 767px)");
   const {
     page,
     sort,
@@ -20,7 +23,14 @@ export default function ProductRegisterHistoryPage() {
   } = useProductRegistrations();
 
   return (
-    <main className="px-8 py-10">
+    <div className="min-h-screen flex flex-col">
+      <Header
+        device={isMobile ? "mobile" : "pc"}
+        isLoggedIn
+        role="member"
+        cartCount={2}
+      />
+      <main className="flex-1 px-8 py-10">
         <section className="mx-auto max-w-6xl">
           <ProductRegisterHeader
             sort={sort}
@@ -46,6 +56,7 @@ export default function ProductRegisterHistoryPage() {
             </div>
           )}
         </section>
-    </main>
+      </main>
+    </div>
   );
 }

--- a/src/app/products/[productId]/page.tsx
+++ b/src/app/products/[productId]/page.tsx
@@ -1,0 +1,34 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { getProductRegistrationById } from "@/app/product-register-history/_lib/api";
+
+interface ProductDetailPageProps {
+  params: Promise<{ productId: string }>;
+}
+
+export default async function ProductDetailPage({ params }: ProductDetailPageProps) {
+  const { productId } = await params;
+  const id = Number(productId);
+  if (!Number.isFinite(id)) {
+    notFound();
+  }
+
+  const product = await getProductRegistrationById(id);
+  if (!product) {
+    notFound();
+  }
+
+  return (
+    <main className="px-8 py-10">
+      <section className="mx-auto max-w-4xl">
+        <Link
+          href="/product-register-history"
+          className="text-sm font-medium text-gray-500 transition-colors hover:text-gray-700"
+        >
+          ← 목록으로
+        </Link>
+        <h1 className="mt-6 text-2xl font-bold text-gray-900">{product.name}</h1>
+      </section>
+    </main>
+  );
+}

--- a/src/hooks/use-media-query.ts
+++ b/src/hooks/use-media-query.ts
@@ -1,0 +1,27 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * 미디어 쿼리 매칭 여부를 반환합니다.
+ * @param query - CSS 미디어 쿼리 (예: "(max-width: 767px)")
+ */
+export function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState(false);
+
+  useEffect(() => {
+    const media = window.matchMedia(query);
+    setMatches(media.matches);
+
+    const listener = (e: MediaQueryListEvent) => setMatches(e.matches);
+    media.addEventListener("change", listener);
+    return () => media.removeEventListener("change", listener);
+  }, [query]);
+
+  return matches;
+}
+
+/** 모바일 뷰포트 (768px 미만) 여부 */
+export function useIsMobile(): boolean {
+  return useMediaQuery("(max-width: 767px)");
+}


### PR DESCRIPTION
- 상품명 클릭 시 /products/:productId 상세 페이지로 이동
- 상품 등록 내역 페이지에 Header 적용


closes #39