### PR TITLE
[feat]상품리스트 및 상세 페이지 반응형 적용

### DIFF
--- a/src/app/productlist/[productId]/page.tsx
+++ b/src/app/productlist/[productId]/page.tsx
@@ -2,6 +2,7 @@ import Image from "next/image"
 import Link from "next/link"
 import { notFound } from "next/navigation"
 import { getProductById } from "../_lib/api"
+import { CONTENT_PADDING_X } from "@/components/header"
 import { ProductDetailPurchaseSection } from "../_components/product-detail-purchase-section"
 import { ProductListGlobalHeader } from "../_components/productlist-global-header"
 
@@ -27,18 +28,18 @@ export default async function ProductDetailPage({ params }: ProductDetailPagePro
     <div className="min-h-screen flex flex-col bg-[#FBF8F4]">
       <ProductListGlobalHeader />
 
-      <main className="flex-1 px-8 py-10">
+      <main className={`flex-1 py-6 md:py-8 lg:py-10 ${CONTENT_PADDING_X}`}>
         <section className="mx-auto max-w-4xl">
           <Link
             href="/productlist"
-            className="text-sm font-medium text-gray-500 transition-colors hover:text-gray-700"
+            className="text-xs font-medium text-gray-500 transition-colors hover:text-gray-700 lg:text-sm"
           >
             ← 목록으로
           </Link>
 
-          <div className="mt-6 overflow-hidden rounded-3xl border border-gray-100 bg-white">
+          <div className="mx-3 mt-4 overflow-hidden rounded-2xl border border-gray-100 bg-white lg:mx-0 lg:mt-6 lg:rounded-3xl">
             <div className="grid grid-cols-1 md:grid-cols-2">
-              <div className="aspect-square w-full bg-gray-100 relative overflow-hidden">
+              <div className="relative aspect-square w-full overflow-hidden bg-gray-100">
                 {product.image ? (
                   <Image
                     src={product.image}
@@ -51,25 +52,25 @@ export default async function ProductDetailPage({ params }: ProductDetailPagePro
                 )}
               </div>
 
-              <div className="p-8">
+              <div className="p-6 lg:p-8">
                 <div className="flex items-center justify-between gap-3">
-                  <p className="text-sm text-gray-500">{product.category}</p>
-                  <span className="rounded-full bg-[var(--secondary-illustration-02)] px-3 py-1 text-xs font-semibold text-[var(--primary-orange-400)]">
+                  <p className="text-xs text-gray-500 lg:text-sm">{product.category}</p>
+                  <span className="rounded-full bg-[var(--secondary-illustration-02)] px-2.5 py-0.5 text-[10px] font-semibold text-[var(--primary-orange-400)] lg:px-3 lg:py-1 lg:text-xs">
                     {product.purchaseCount}회 구매
                   </span>
                 </div>
 
-                <h1 className="mt-3 text-2xl font-bold text-gray-900">
+                <h1 className="mt-2 text-xl font-bold text-gray-900 lg:mt-3 lg:text-2xl">
                   {product.name}
                 </h1>
 
-                <p className="mt-6 text-3xl font-extrabold text-gray-900">
+                <p className="mt-4 text-2xl font-extrabold text-gray-900 lg:mt-6 lg:text-3xl">
                   {product.price.toLocaleString()}원
                 </p>
 
                 <ProductDetailPurchaseSection productName={product.name} unitPrice={product.price} />
 
-                <p className="mt-6 text-xs text-gray-400">
+                <p className="mt-4 text-[11px] text-gray-400 lg:mt-6 lg:text-xs">
                   목업 데이터 기반 상세입니다. 실제 연동 시 포인트·배송·장바구니 API에 맞게 교체할 수 있어요.
                 </p>
               </div>

--- a/src/app/productlist/_components/product-detail-purchase-section.tsx
+++ b/src/app/productlist/_components/product-detail-purchase-section.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useState, type ReactNode } from "react"
 import { ChevronUp, ChevronDown } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
@@ -13,10 +13,10 @@ interface ProductDetailPurchaseSectionProps {
   unitPrice: number
 }
 
-function DetailRow({ label, children }: { label: string; children: React.ReactNode }) {
+function DetailRow({ label, children }: { label: string; children: ReactNode }) {
   return (
-    <div className="flex gap-4 border-b border-gray-100 py-3 text-sm last:border-b-0">
-      <span className="w-24 shrink-0 font-medium text-gray-500">{label}</span>
+    <div className="flex gap-3 border-b border-gray-100 py-2.5 text-xs last:border-b-0 lg:gap-4 lg:py-3 lg:text-sm">
+      <span className="w-20 shrink-0 font-medium text-gray-500 lg:w-24">{label}</span>
       <div className="min-w-0 flex-1 text-gray-800">{children}</div>
     </div>
   )
@@ -41,10 +41,10 @@ export function ProductDetailPurchaseSection({ productName, unitPrice }: Product
   }
 
   return (
-    <div className="mt-8 space-y-6">
-      <div className="rounded-2xl border border-gray-100 bg-gray-50/80 px-5 py-1">
+    <div className="mt-6 space-y-4 lg:mt-8 lg:space-y-6">
+      <div className="rounded-2xl border border-gray-100 bg-gray-50/80 px-4 py-1 lg:px-5">
         <DetailRow label="구매혜택">
-          <span className="font-semibold text-[var(--primary-orange-400,#E5762C)]">
+          <span className="font-semibold text-[var(--primary-orange-400)]">
             {expectedPoints.toLocaleString()}포인트
           </span>{" "}
           적립 예정
@@ -57,11 +57,13 @@ export function ProductDetailPurchaseSection({ productName, unitPrice }: Product
         </DetailRow>
       </div>
 
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
-        <div className={cn(
-          "flex h-12 w-full shrink-0 items-center justify-between rounded-xl border border-gray-200 bg-white px-4 sm:w-[120px]"
-        )}>
-          <span className="text-sm font-bold text-[#E5762C]">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-stretch">
+        <div
+          className={cn(
+            "flex h-14 w-full shrink-0 items-center justify-between rounded-xl border border-gray-200 bg-white px-4 sm:h-12 sm:w-[120px] lg:h-12",
+          )}
+        >
+          <span className="text-sm font-bold text-[#E5762C] lg:text-base">
             {quantity}개
           </span>
           
@@ -91,18 +93,18 @@ export function ProductDetailPurchaseSection({ productName, unitPrice }: Product
         <Button
           type="button"
           variant="solid"
-          className="h-12 min-w-0 flex-1 rounded-2xl px-6 text-base font-semibold sm:w-auto sm:min-w-[200px]"
+          className="h-14 w-full shrink-0 rounded-2xl px-6 text-base font-semibold !w-full sm:h-12 sm:!w-auto sm:min-w-[200px] sm:flex-1 lg:text-base"
           onClick={handleAddToCart}
         >
           장바구니 담기
         </Button>
       </div>
-      <div className="flex justify-between border-t border-gray-100 pt-4">
-        <span className="text-base font-medium text-gray-900">총 상품 금액</span>
-        <span className="text-xl font-bold text-gray-900">{lineTotal.toLocaleString()}원</span>
+      <div className="flex justify-between border-t border-gray-100 pt-3 lg:pt-4">
+        <span className="text-sm font-medium text-gray-900 lg:text-base">총 상품 금액</span>
+        <span className="text-lg font-bold text-gray-900 lg:text-xl">{lineTotal.toLocaleString()}원</span>
       </div>
       {cartMessage ? (
-        <p className="text-sm text-gray-600" role="status">
+        <p className="text-xs text-gray-600 lg:text-sm" role="status">
           {cartMessage}
         </p>
       ) : null}

--- a/src/app/productlist/_components/product-register-modal.tsx
+++ b/src/app/productlist/_components/product-register-modal.tsx
@@ -40,8 +40,8 @@ function CategorySelect({
     : []
 
   return (
-    <div className="flex gap-3">
-      <div className="relative flex-1">
+    <div className="flex flex-col gap-3 sm:flex-row sm:items-stretch">
+      <div className="relative min-w-0 flex-1">
         <select
           value={selectedMainId ?? ""}
           onChange={(e) => {
@@ -63,7 +63,7 @@ function CategorySelect({
         </select>
         <ChevronDown className="pointer-events-none absolute right-3 top-1/2 size-5 -translate-y-1/2 text-[#E5762C]" />
       </div>
-      <div className="relative flex-1">
+      <div className="relative min-w-0 flex-1">
         <select
           value={selectedSubId ?? ""}
           onChange={(e) => {
@@ -105,7 +105,7 @@ export function ProductRegisterModal({ open, onOpenChange }: ProductRegisterModa
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-[500px] p-8 sm:max-w-[90vw]">
+      <DialogContent className="max-h-[min(90dvh,90vh)] w-full max-w-[500px] overflow-y-auto p-6 lg:p-8">
         <DialogHeader>
           <DialogTitle>상품 등록</DialogTitle>
         </DialogHeader>

--- a/src/app/productlist/_components/productlist-add-product-button.tsx
+++ b/src/app/productlist/_components/productlist-add-product-button.tsx
@@ -11,16 +11,17 @@ export function ProductListAddProductButton({ onClick }: ProductListAddProductBu
       type="button"
       onClick={onClick}
       className={cn(
-        "fixed bottom-[120px] right-[120px]",
-        "flex h-12 w-28 items-center justify-center rounded-full",
+        "fixed bottom-20 right-4 z-40 md:bottom-24 md:right-8",
+        "lg:bottom-[120px] lg:right-[clamp(24px,6.25vw,120px)]",
+        "flex h-11 w-[7.25rem] items-center justify-center rounded-full lg:h-12 lg:w-28",
         "bg-[var(--secondary-illustration-06)] text-white shadow-lg",
         "transition-transform hover:translate-y-[-2px] hover:shadow-xl",
         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[var(--secondary-illustration-06)]"
       )}
       aria-label="상품 등록"
     >
-      <Plus className="h-5 w-5" aria-hidden="true" />
-      <span className="text-base font-semibold">상품 등록</span>
+      <Plus className="h-4 w-4 lg:h-5 lg:w-5" aria-hidden="true" />
+      <span className="text-sm font-semibold lg:text-base">상품 등록</span>
     </button>
   )
 }

--- a/src/app/productlist/_components/productlist-filters.tsx
+++ b/src/app/productlist/_components/productlist-filters.tsx
@@ -29,7 +29,7 @@ return (
         <button
           onClick={() => onSelectCategory(null)}
           className={cn(
-            "relative pb-2 text-lg font-medium transition-colors",
+            "relative pb-2 text-base font-medium transition-colors lg:text-lg",
             isAllSelected ? "text-orange-500" : "text-gray-500 hover:text-gray-700"
           )}
         >
@@ -46,7 +46,7 @@ return (
               key={c.id}
               onClick={() => onSelectCategory(c.id)}
               className={cn(
-                "relative pb-2 text-lg font-medium transition-colors",
+                "relative pb-2 text-base font-medium transition-colors lg:text-lg",
                 isSelected ? "text-orange-500" : "text-gray-500 hover:text-gray-700"
               )}
             >
@@ -65,7 +65,7 @@ return (
           <button
             onClick={() => onSelectSubCategory(null)}
             className={cn(
-              "rounded-full px-4 py-1 text-sm transition-all",
+              "rounded-full px-4 py-1 text-xs transition-all lg:text-sm",
               selectedSubCategoryId === null
                 ? "bg-orange-50 text-orange-600 font-semibold"
                 : "text-gray-500 hover:bg-gray-50"
@@ -81,7 +81,7 @@ return (
                 key={s.id}
                 onClick={() => onSelectSubCategory(s.id)}
                 className={cn(
-                  "rounded-full px-4 py-1 text-sm transition-all",
+                  "rounded-full px-4 py-1 text-xs transition-all lg:text-sm",
                   isSelected
                     ? "bg-orange-50 text-orange-600 font-semibold"
                     : "text-gray-500 hover:bg-gray-50"

--- a/src/app/productlist/_components/productlist-grid.tsx
+++ b/src/app/productlist/_components/productlist-grid.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import Link from "next/link"
-import { ProductCard } from "@/components/ui/card"
+import { ProductListProductCard } from "./productlist-product-card"
 import type { Product } from "../_lib/types"
 
 interface ProductListGridProps {
@@ -21,20 +21,14 @@ export function ProductListGrid({ products, loading = false }: ProductListGridPr
           조회된 상품이 없습니다.
         </div>
       ) : (
-        <div className="flex flex-wrap justify-start gap-6">
+        <div className="grid grid-cols-2 gap-4 md:grid-cols-3 md:gap-6 lg:grid-cols-4">
           {products.map((product) => (
             <Link
               key={product.id}
               href={`/productlist/${product.id}`}
-              className="transition-transform hover:-translate-y-0.5"
+              className="block min-w-0 transition-transform hover:-translate-y-0.5"
             >
-              <ProductCard
-                image={product.image}
-                category={product.category}
-                purchaseCount={product.purchaseCount}
-                name={product.name}
-                price={product.price}
-              />
+              <ProductListProductCard product={product} />
             </Link>
           ))}
         </div>

--- a/src/app/productlist/_components/productlist-header.tsx
+++ b/src/app/productlist/_components/productlist-header.tsx
@@ -44,7 +44,7 @@ export function ProductListHeader({
 
   return (
     <header className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-      <h1 className="text-3xl font-bold text-[#37352f]">상품 리스트</h1>
+      <h1 className="text-2xl font-bold text-[#37352f] lg:text-3xl">상품 리스트</h1>
 
       <div className="flex flex-col gap-3 md:flex-row md:items-center">
         <Input

--- a/src/app/productlist/_components/productlist-product-card.tsx
+++ b/src/app/productlist/_components/productlist-product-card.tsx
@@ -1,0 +1,45 @@
+"use client"
+
+import type { ComponentProps } from "react"
+import { cn } from "@/lib/utils"
+import type { Product } from "../_lib/types"
+
+/** 상품 리스트 전용: 공용 ProductCard는 고정 327px 유지, 그리드 셀에 맞춘 반응형 카드 */
+export function ProductListProductCard({
+  product,
+  className,
+  ...props
+}: { product: Product } & ComponentProps<"div">) {
+  const { image, category, purchaseCount, name, price } = product
+  return (
+    <div
+      data-slot="productlist-product-card"
+      className={cn(
+        "w-full min-w-0 overflow-hidden rounded-[20px] border border-gray-100 bg-white shadow-sm",
+        className,
+      )}
+      {...props}
+    >
+      <div className="aspect-square w-full overflow-hidden bg-gray-100">
+        {image ? (
+          <img src={image} alt={name} className="h-full w-full object-cover" />
+        ) : (
+          <div className="h-full w-full bg-gray-200" />
+        )}
+      </div>
+
+      <div className="p-3 lg:p-4">
+        <div className="mb-2 flex items-center justify-between gap-2">
+          <span className="min-w-0 truncate text-xs text-gray-500 lg:text-sm">{category}</span>
+          <span className="shrink-0 rounded-full bg-[#FDF0DF] px-2 py-0.5 text-[10px] font-medium text-[#E5762C] lg:px-3 lg:py-1 lg:text-xs">
+            {purchaseCount}회 구매
+          </span>
+        </div>
+
+        <h3 className="mb-2 line-clamp-2 text-sm font-medium text-gray-900 lg:text-base">{name}</h3>
+
+        <p className="text-lg font-bold text-gray-900 lg:text-xl">{price.toLocaleString()}원</p>
+      </div>
+    </div>
+  )
+}

--- a/src/app/productlist/page.tsx
+++ b/src/app/productlist/page.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState } from "react"
+import { CONTENT_PADDING_X } from "@/components/header"
 import Pagination from "@/components/ui/pagination"
 import { ProductListAddProductButton } from "./_components/productlist-add-product-button"
 import { ProductRegisterModal } from "./_components/product-register-modal"
@@ -42,8 +43,8 @@ export default function ProductListPage() {
     <div className="min-h-screen flex flex-col bg-[#FBF8F4]">
       <ProductListGlobalHeader />
 
-      <main className="flex-1 px-8 py-10">
-        <section className="mx-auto max-w-6xl">
+      <main className={`flex-1 py-6 md:py-8 lg:py-10 ${CONTENT_PADDING_X}`}>
+        <section className="mx-auto max-w-7xl">
           <ProductListHeader
             keyword={keyword}
             onChangeKeyword={setKeyword}


### PR DESCRIPTION
상품리스트와 상품상세 페이지에 반응형 ui를 적용하였습니다.
* 공용 컴포넌트 헤더의 반응형 breakpoint에 따라 이하 UI에 반응형 구조를 적용하였습니다.
* 상품 리스트 페이지의 데스크탑 화면에서 상품 카드 그리드 배치를 피그마 디자인에 맞게 3열에서 4열로 수정하였습니다.
* 상품 등록 버튼을 눌렀을 때 나타나는 모달의 사이즈가 비정상적으로 커서, 이를 정상적으로 수정하였습니다.
* 상품 상세페이지에서 card 컴포넌트의 반응형 ui를 효과적으로 적용하기 위해, productlist 폴더 내에 개별 컴포넌트를 생성, 적용하였습니다. 공용 card 컴포넌트에는 영향이 없습니다.